### PR TITLE
add benchmarks

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -134,3 +134,36 @@ func TestServer_ServeHTTP_health(t *testing.T) {
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, "OK\n", w.Body.String())
 }
+
+type responseWriterNoOp struct {
+}
+
+func (*responseWriterNoOp) Header() http.Header {
+	return nil
+}
+
+func (*responseWriterNoOp) Write([]byte) (int, error) {
+	return 0, nil
+}
+
+func (*responseWriterNoOp) WriteHeader(int) {
+}
+
+func BenchmarkServe(b *testing.B) {
+	p := new(pub)
+
+	s := Server{
+		Log:       log.New(ioutil.Discard, "", log.LstdFlags),
+		Topic:     "builds",
+		Publisher: p,
+	}
+
+	for i := 0; i < b.N; i++ {
+		r, err := http.NewRequest("POST", "/build", bytes.NewBufferString(`{ "foo": "bar" }`))
+		if err != nil {
+			b.Error(err)
+		}
+		r.Header.Set("Content-Type", "application/json")
+		s.ServeHTTP(&responseWriterNoOp{}, r)
+	}
+}


### PR DESCRIPTION
I want to optimize the JSON parsing code by switching to
`json.RawMessage`. So I wanted to add benchmarks first to
estabilish a baseline.

```
$ go test -bench ./...
BenchmarkServe-8         1000000              1528 ns/op
PASS
ok      github.com/segmentio/http_to_nsq        1.562s
```