### PR TITLE
Speed up JSON parsing.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,10 +22,10 @@ $ go get github.com/segmentio/http_to_nsq/cmd/http_to_nsq
 
 ```go
 type Message struct {
-  URL    string                 `json:"url"`
-  Method string                 `json:"method"`
-  Header http.Header            `json:"header"`
-  Body   map[string]interface{} `json:"body"`
+	URL    string          `json:"url"`
+	Method string          `json:"method"`
+	Header http.Header     `json:"header"`
+	Body   json.RawMessage `json:"body"`
 }
 ```
 

--- a/server.go
+++ b/server.go
@@ -14,10 +14,10 @@ type publisher interface {
 
 // Message published to NSQD.
 type Message struct {
-	URL    string                 `json:"url"`
-	Method string                 `json:"method"`
-	Header http.Header            `json:"header"`
-	Body   map[string]interface{} `json:"body"`
+	URL    string          `json:"url"`
+	Method string          `json:"method"`
+	Header http.Header     `json:"header"`
+	Body   json.RawMessage `json:"body"`
 }
 
 // Server publishing requests as Messages.
@@ -40,7 +40,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // Publish requests to NSQD.
 func (s *Server) publish(w http.ResponseWriter, r *http.Request) {
-	var body map[string]interface{}
+	var body json.RawMessage
 
 	secret := r.URL.Query().Get("secret")
 


### PR DESCRIPTION
By switching to `json.RawMessage` over `map[string]interface{}`, we can
speed up JSON parsing (as we did for nsq_to_redis).

```
 $ benchcmp old.txt new.txt
 benchmark            old ns/op     new ns/op     delta
 BenchmarkServe-8     1601          1485          -7.25%
```