### PR TITLE
Respect CLI --topic flag.

### DIFF
--- a/cmd/http_to_nsq/main.go
+++ b/cmd/http_to_nsq/main.go
@@ -40,6 +40,7 @@ func main() {
 	topic := args["--topic"].(string)
 	addr := args["--address"].(string)
 	nsqd := args["--nsqd-tcp-address"].(string)
+	secret := args["--secret"].(string)
 
 	log.Printf("starting http_to_nsq %s", Version)
 	log.Printf("--> binding to %s", addr)
@@ -52,8 +53,8 @@ func main() {
 
 	server := &http_to_nsq.Server{
 		Log:       log.New(os.Stderr, "", log.LstdFlags),
-		Secret:    args["--secret"].(string),
-		Topic:     "builds",
+		Secret:    secret,
+		Topic:     topic,
 		Publisher: prod,
 	}
 


### PR DESCRIPTION
Currently we ignore the --topic flag and always publish to the "builds"
topic.

This fixes it so that we respect the topic. I'll update our terraform
config (the issue that Chris mentioned earlier) so that it continues to
publish to "builds".

Closes #3 and #5 