### PR TITLE
Require requests to be POST, PUT or DELETE.

### DIFF
--- a/server.go
+++ b/server.go
@@ -40,16 +40,20 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // Publish requests to NSQD.
 func (s *Server) publish(w http.ResponseWriter, r *http.Request) {
-	var body json.RawMessage
+	if r.Method != "POST" && r.Method != "PUT" && r.Method != "DELETE" {
+		s.Log.Printf("[error] invalid method: %s", r.Method)
+		http.Error(w, http.StatusText(405), 405)
+		return
+	}
 
 	secret := r.URL.Query().Get("secret")
-
 	if s.Secret != "" && s.Secret != secret {
 		s.Log.Printf("[error] invalid secret")
 		http.Error(w, http.StatusText(403), 403)
 		return
 	}
 
+	var body json.RawMessage
 	err := json.NewDecoder(r.Body).Decode(&body)
 	if err != nil {
 		s.Log.Printf("[error] decoding body: %s", err)


### PR DESCRIPTION
This is because the code requires a request body, which may be only sent
as part of the above requests.