### PR TITLE
Allow requests with empty bodies (e.g. GET)

### DIFF
--- a/server.go
+++ b/server.go
@@ -40,21 +40,21 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // Publish requests to NSQD.
 func (s *Server) publish(w http.ResponseWriter, r *http.Request) {
-	var body json.RawMessage
-
 	secret := r.URL.Query().Get("secret")
-
 	if s.Secret != "" && s.Secret != secret {
 		s.Log.Printf("[error] invalid secret")
 		http.Error(w, http.StatusText(403), 403)
 		return
 	}
 
-	err := json.NewDecoder(r.Body).Decode(&body)
-	if err != nil {
-		s.Log.Printf("[error] decoding body: %s", err)
-		http.Error(w, "Error parsing request body", 400)
-		return
+	var body json.RawMessage
+	if r.Body != nil {
+		err := json.NewDecoder(r.Body).Decode(&body)
+		if err != nil {
+			s.Log.Printf("[error] decoding body: %s", err)
+			http.Error(w, "Error parsing request body", 400)
+			return
+		}
 	}
 
 	msg := &Message{

--- a/server_test.go
+++ b/server_test.go
@@ -45,6 +45,28 @@ func TestServer_ServeHTTP_POST(t *testing.T) {
 	assert.Equal(t, ":)", w.Body.String())
 }
 
+func TestServer_ServeHTTP_GET(t *testing.T) {
+	p := new(pub)
+
+	s := Server{
+		Log:       log.New(ioutil.Discard, "", log.LstdFlags),
+		Topic:     "builds",
+		Publisher: p,
+	}
+
+	r, err := http.NewRequest("GET", "/build", nil)
+	assert.Equal(t, nil, err)
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, r)
+
+	assert.Equal(t, 1, len(p.msgs))
+	assert.Equal(t, `{"url":"/build","method":"GET","header":{},"body":null}`, string(p.msgs[0]))
+
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, ":)", w.Body.String())
+}
+
 func TestServer_ServeHTTP_secret_invalid(t *testing.T) {
 	p := new(pub)
 


### PR DESCRIPTION
Alternative to #11 .

Instead of being strict and disallowing the methods that we would previously fail on, this relaxes the server and gracefully handles requests that don't have any body.